### PR TITLE
Create terraform module for ECS agents

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,20 @@
+name: Generate terraform docs
+on:
+  - pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Render terraform docs and push changes back to PR
+        uses: terraform-docs/gh-actions@main
+        with:
+          working-dir: .
+          config-file: .terraform-docs.yml
+          output-file: README.md
+          output-method: inject
+          git-push: "true"

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: "markdown"
+
+sections:
+  hide:
+    - providers
+    - modules
+
+sort:
+  enabled: true
+  by: required

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.70.0"
+  hashes = [
+    "h1:E5IKHXzPGGSizZM5rHKzNCzpwQ7lWPXmmJnms82uzDk=",
+    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
+    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
+    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
+    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
+    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
+    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
+    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
+    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
+    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
+    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
+    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # terraform-ecs-airplane-cluster
-Terraform module for running Airplane agents in AWS using ECS
+
+This terraform module creates an ECS cluster running Airplane agents.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-ecs-airplane-cluster
+# terraform-aws-agents
 
 This terraform module creates an ECS cluster running Airplane agents.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # terraform-ecs-airplane-cluster
 
 This terraform module creates an ECS cluster running Airplane agents.
+
+To get started, you'll need an `api_token` and your `team_id`.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,24 @@
 This terraform module creates an ECS cluster running Airplane agents.
 
 To get started, you'll need an `api_token` and your `team_id`.
+
+Use this module in your Terraform configuration:
+
+```hcl
+module "airplane_agent" {
+  source = "airplanedev/airplane-cluster/ecs"
+  version = "~> 0.4.0"
+
+  api_token = "YOUR_API_TOKEN"
+  team_id = "YOUR_TEAM_ID"
+
+  # Set which subnets agents should live in
+  subnet_ids = ["subnet-000", "subnet-111"]
+
+  # Optional: attach labels to agents for task constraints
+  agent_labels = {
+    vpc = "123"
+    env = "test"
+  }
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,200 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_ecs_cluster" "cluster" {
+  name = "airplane-ecs-cluster"
+  capacity_providers = ["FARGATE"]
+  count = var.cluster_arn == "" ? 1 : 0
+}
+
+resource "aws_iam_policy" "default_run_policy" {
+  policy = jsonencode({
+    Version = "2021-10-17"
+    Statement = [
+      {
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = join(":", ["arn:aws:secretsmanager", data.aws_region.current.name, data.aws_caller_identity.current.account_id, "secret:airplane/*"])
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "default_run_role" {
+  assume_role_policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "sts:AssumeRole"
+        ]
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+    aws_iam_policy.default_run_policy.name
+  ]
+}
+
+resource "aws_iam_role" "agent_role" {
+  assume_role_policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "sts:AssumeRole"
+        ]
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+  inline_policy {
+    name = "airplane-agent-policy"
+    policy = jsonencode({
+      Statement = concat([
+        {
+          Action = [
+            "ecs:DescribeTasks",
+            "ecs:RegisterTaskDefinition",
+            "ecs:DeregisterTaskDefinition",
+            "ecs:RunTask",
+            "ecs:StopTask",
+            "ecs:TagResource",
+            "iam:PassRole",
+            "logs:GetLogEvents",
+          ],
+          Resource = "*"
+          Effect = "Allow"
+        },
+        {
+          Action = [
+            "secretsmanager:CreateSecret",
+            "secretsmanager:DeleteSecret",
+            "secretsmanager:DescribeSecret",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:TagResource",
+          ]
+          Resource = join(":", ["arn:aws:secretsmanager", data.aws_region.current.name, data.aws_caller_identity.current.account_id, "secret:airplane/*"])
+          Effect = "Allow"
+        },
+      ], 
+      var.api_token_secret_arn == "" ? [] : [{
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = var.api_token_secret_arn
+        Effect = "Allow"
+      }], 
+      var.api_token_secret_kms_key_arn == "" ? [] : [{
+        Action = [
+          "kms:Decrypt"
+        ]
+        Resource = var.api_token_secret_kms_key_arn
+        Effect = "Allow"
+      }])
+    })
+  }
+}
+
+resource "aws_iam_role" "agent_execution_role" {
+  assume_role_policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "sts:AssumeRole"
+        ]
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+  inline_policy {
+    name = "airplane-agent-policy"
+    policy = jsonencode({
+      Statement = [
+        {
+          Action = [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+          ]
+          Resource = "*"
+          Effect = "Allow"
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_ecs_task_definition" "agent_task_def" {
+  family = "airplane/agent-task-def"
+  container_definitions = jsonencode([
+    {
+      name = "airplane-agent"
+      image = "airplanedev/agent:1"
+      environment = [
+        {name = "AP_API_HOST", value = var.api_host},
+        {name = "AP_API_TOKEN", value = var.api_token},
+        {name = "AP_API_TOKEN_SECRET_ARN", value = var.api_token_secret_arn},
+        {name = "AP_AWS_REGION", value = data.aws_region.current.name},
+        {name = "AP_AUTO_UPGRADE", value = "true"},
+        {name = "AP_DRIVER", value = "ecs"},
+        {name = "AP_ECS_CLUSTER", value = var.cluster_arn == "" ? aws_ecs_cluster.cluster[0].arn : var.cluster_arn},
+        {name = "AP_ECS_EXECUTION_ROLE", value = aws_iam_role.default_run_role.arn},
+        {name = "AP_ECS_LOG_GROUP", value = aws_cloudwatch_log_group.run_log_group.arn},
+        {name = "AP_ECS_SUBNETS", value = join(",", var.subnet_ids)},
+        {name = "AP_LABELS", value = join(",", [for key, value in var.agent_labels : "${key}:${value}"])}, 
+        {name = "AP_PARALLELISM", value = "50"},
+        {name = "AP_TEAM_ID", value = var.team_id},
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-region" = data.aws_region.current.name
+          "awslogs-group" = aws_cloudwatch_log_group.agent_log_group.arn
+          "awslogs-stream-prefix" = "agent"
+        }
+      }
+    }
+  ])
+  cpu = 256
+  memory = 512
+  network_mode = "awsvpc"
+  task_role_arn = aws_iam_role.agent_role.arn
+  execution_role_arn = aws_iam_role.agent_execution_role.arn
+  runtime_platform {
+    cpu_architecture = "X86_64"
+    operating_system_family = "LINUX"
+  }
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "agent_service" {
+  name = var.service_name
+  cluster = var.cluster_arn == "" ? aws_ecs_cluster.cluster[0].arn : var.cluster_arn
+  desired_count = 3
+  launch_type = "FARGATE"
+  network_configuration {
+    assign_public_ip = true
+    subnets = var.subnet_ids
+  }
+  task_definition = aws_ecs_task_definition.agent_task_def.arn
+}
+
+resource "aws_cloudwatch_log_group" "agent_log_group" {
+  name = "/airplane/agents"
+}
+
+resource "aws_cloudwatch_log_group" "run_log_group" {
+  name = "/airplane/runs"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,55 @@
+// Required variables.
+variable "team_id" {
+  type        = string
+  description = "Airplane team ID - retrieve via `airplane auth info`."
+}
+
+// Optional variables.
+variable "api_host" {
+  type        = string
+  description = "For development purposes."
+  default     = "https://api.airplane.dev"
+}
+
+variable "api_token" {
+  type        = string
+  description = "Airplane API key - generate one via `airplane apikeys create`. EIther this or API Token Secret must be set"
+  sensitive   = true
+  default     = ""
+}
+
+variable "api_token_secret_arn" {
+  type = string
+  description = "ARN of API Token stored in AWS secret. Either this or API Token must be set."
+  default = ""
+}
+
+variable "api_token_secret_kms_key_arn" {
+  type = string
+  description = "ARN of customer-managed KMS key, if any, used to encrypt API Token Secret."
+  default = ""
+}
+
+variable "cluster_arn" {
+  type = string
+  description = "Your ECS cluster ARN. Leave blank to create a new cluster."
+  default = ""
+}
+
+variable "agent_labels" {
+  type        = map(string)
+  description = "Map of label key/values to attach to agents. Labels can be used to constrain where tasks execute."
+  default     = {ecs: "true"}
+}
+
+variable "service_name" {
+  type = string
+  description = "Name to assign to ECS service"
+  default = "airplane-agent"
+}
+
+variable "subnet_ids" {
+  type = list(string)
+  description = "List of subnet IDs for ECS service"
+  default = []
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    aws = ">= 3.22.0"
+  }
+}


### PR DESCRIPTION
Basically a direct translation of the cloudformation stack.

Ran this command to test: `terraform apply -var 'cluster_arn=' -var 'team_id=1jq9NDeTcTmyqqXAjEsk7V0wXaV' -var 'api_host=https://workos-airplane.ngrok.io' -var 'subnet_ids=["subnet-069d2a8d1f459eef3"]' -var 'api_token=tkn_gIUh8Yay7MVKH4A5TpvsjhdixGVTKIKe4hTF'`

---
@joshma if it looks good, I'll merge and figure out how to deploy onto the terraform registry. Also, wasn't sure if I should be putting it on the other repo or just creating this fresh repo, let me know if you have a preference